### PR TITLE
Add non bare scripts option?

### DIFF
--- a/src/Web.Optimization.Bundles.CoffeeScript/CoffeeScriptTransform.cs
+++ b/src/Web.Optimization.Bundles.CoffeeScript/CoffeeScriptTransform.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 using System.Web;
 using System.Web.Optimization;
@@ -12,6 +13,12 @@ namespace Web.Optimization.Bundles.CoffeeScript
     /// </summary>
     public class CoffeeScriptTransform : IBundleTransform
     {
+        private readonly bool useBareScripts;
+        public CoffeeScriptTransform(bool? useBareScripts= null)
+        {
+            //default to bare scripts.
+            this.useBareScripts = useBareScripts ?? true;
+        }
         public void Process(BundleContext context, BundleResponse response)
         {
             var coffeeScriptPath =
@@ -33,8 +40,9 @@ namespace Web.Optimization.Bundles.CoffeeScript
             engine.Execute(coffeeScriptCompiler);
 
             // Initializes a wrapper function for the CoffeeScript compiler.
-            engine.Execute("var compile = function (src) { return CoffeeScript.compile(src, { bare: true }); };");
-
+            engine.Execute(String.Format(
+                "var compile = function (src) {{ return CoffeeScript.compile(src, {{ bare: {0} }}); }};",
+                useBareScripts.ToString().ToLower()));
             try
             {
                 var js = engine.CallGlobalFunction("compile", response.Content);

--- a/src/Web.Optimization.Bundles.CoffeeScript/CombinedCoffeeScriptTransform.cs
+++ b/src/Web.Optimization.Bundles.CoffeeScript/CombinedCoffeeScriptTransform.cs
@@ -11,6 +11,11 @@ namespace Web.Optimization.Bundles.CoffeeScript
     /// </summary>
     public class CombinedCoffeeScriptTransform : IBundleTransform
     {
+        private readonly bool useBareCoffeeScripts;
+        public CombinedCoffeeScriptTransform(bool? useBareCoffeeScripts = null)
+        {
+            this.useBareCoffeeScripts = useBareCoffeeScripts ?? true;
+        }
         public void Process(BundleContext context, BundleResponse response)
         {
             var builder = new StringBuilder();
@@ -23,7 +28,7 @@ namespace Web.Optimization.Bundles.CoffeeScript
                     ".coffee",
                     StringComparison.OrdinalIgnoreCase))
                 {
-                    transform = new CoffeeScriptTransform();
+                    transform = new CoffeeScriptTransform(useBareCoffeeScripts);
                 }
                 else if (file.Extension.Equals(
                     ".js",


### PR DESCRIPTION
A possible commit for philipproplesch/web.optimization#2

CoffeeScriptTransform and CombinedCoffeeScriptTransform have a new
optional constructor parameter useBare[Coffee]Scripts. It defaults to
true, to maintain previous behaviour.
